### PR TITLE
updating babel config to allow for es, removal of ramda to allow anyo…

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,26 @@
 {
-  "presets": ["react", "env", "stage-2", "flow"],
-  "plugins": [["flow-react-proptypes", { "ignoreNodeModules": true }]]
+  "env": {
+    "development": {
+      "presets": ["env", "react", "stage-2", "flow"],
+      "plugins": [["flow-react-proptypes", { "ignoreNodeModules": true }]]
+    },
+    "test": {
+      "presets": ["env", "react", "stage-2", "flow"],
+      "plugins": [["flow-react-proptypes", { "ignoreNodeModules": true }]]
+    },
+    "es": {
+      "presets": [
+        [
+          "env",
+          {
+            "modules": false
+          }
+        ],
+        "react",
+        "stage-2",
+        "flow"
+      ],
+      "plugins": [["flow-react-proptypes", { "ignoreNodeModules": true }]]
+    }
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 node_modules
 lib
+es
 .vscode/
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # react-jsx-super-table
+[![npm](https://img.shields.io/npm/v/react-jsx-super-table.svg)](https://www.npmjs.com/package/react-jsx-super-table)
+
 
 #### A lightweight table for a React app which takes JSX for the body (instead of a config). There's also config options for searching fields and sorting columns.
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import SuperTable from '../src/index';
+import SuperTable from '../src/';
 
 describe('<SuperTable />', () => {
   const callback = jest.fn();
@@ -8,31 +8,31 @@ describe('<SuperTable />', () => {
     <SuperTable
       bodyClassName="bodyClassName"
       className="className"
-      data={[{
-        values: 'First Org',
-        row: (
-          <tr
-            key={1}
-          >
-            <td>
-              First Org
-            </td>
-          </tr>
-        )
-      }]}
+      data={[
+        {
+          values: 'First Org',
+          row: (
+            <tr key={1}>
+              <td>First Org</td>
+            </tr>
+          ),
+        },
+      ]}
       errorBodyClassName="errorBodyClassName"
       footer={<p>Pagination could go here.</p>}
-      headers={[{
-        key: 'name',
-        value: 'Name'
-      }]}
+      headers={[
+        {
+          key: 'name',
+          value: 'Name',
+        },
+      ]}
       headClassName="headClassName"
       searchInputClassName="searchInputClassName"
       sortingIconClassName="sortingIconClassName"
       tableClassName="tableClassName"
       titleTextClassName="titleTextClassName"
       onHeaderSortClick={callback}
-    />
+    />,
   );
 
   it('Should test all class names', () => {

--- a/package.json
+++ b/package.json
@@ -10,13 +10,15 @@
   "jsnext:main": "es/index.js",
   "unpkg": "dist/SuperTable.min.js",
   "scripts": {
-    "build": "babel src/ -d lib/",
+    "build": "npm run transpile:lib && npm run transpile:es",
     "clean": "rimraf lib",
     "precommit": "npm test && lint-staged",
     "flow": "flow",
     "test": "jest",
     "dev": "webpack-dev-server --hot --inline --progress --colors --config=webpack.config.js",
     "start": "npm run dev",
+    "transpile:lib": "babel src/ -d lib/",
+    "transpile:es": "BABEL_ENV=es babel src/ -d es/",
     "prepublish": "npm run clean && npm run build"
   },
   "lint-staged": {
@@ -31,7 +33,6 @@
   },
   "keywords": ["react", "component", "table", "grid"],
   "dependencies": {
-    "ramda": "0.25.0",
     "react-debounce-input": "3.2.0"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 /* @flow */
 import * as React from 'react';
-import { isEmpty, pluck } from 'ramda';
 import { DebounceInput } from 'react-debounce-input';
 
 type Props = {
@@ -94,7 +93,7 @@ class SuperTable extends React.Component<Props, State> {
               ))}
             </tr>
           </thead>
-          {isEmpty(data) ? (
+          {!data.length ? (
             <tbody className={errorBodyClassName}>
               <tr>
                 <td className="empty--cell" colSpan={colSpanForEmpty}>
@@ -103,7 +102,7 @@ class SuperTable extends React.Component<Props, State> {
               </tr>
             </tbody>
           ) : (
-            <tbody className={bodyClassName}>{pluck('row', newData)}</tbody>
+            <tbody className={bodyClassName}>{newData.map(({ row }) => row)}</tbody>
           )}
         </table>
         {footer}


### PR DESCRIPTION
Noticed that the es/module field build isn't actually being generated, so it will break when people try to import this module with webpack. 

This PR just includes a fix for that as well as the removal of ramda to just use vanilla JS so people don't have to do `yarn add ramda` to use this. It should also pretty significantly reduce your bundle size. Feel free to give this a test to make sure everything is still ok :)